### PR TITLE
fix: ESLintエラーを修正してVercelデプロイを復旧

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Link from 'next/link';
+import Image from 'next/image';
 import { posts, getPostBySlug } from '../../../lib/posts';
 
 export async function generateStaticParams() {
@@ -29,7 +30,7 @@ export default async function PostPage({ params }: { params: { slug: string } | 
         <article className="p-10 bg-white/5 border border-white/5 rounded-2xl shadow-sm max-w-3xl mx-auto">
           {post.cover && (
             <div className="mb-6 overflow-hidden rounded-xl">
-              <img src={post.cover} alt={post.title} className="w-full h-64 object-cover" />
+              <Image src={post.cover} alt={post.title} width={800} height={256} className="w-full h-64 object-cover" />
             </div>
           )}
           <h1 className="text-3xl font-bold mb-2 text-white">{post.title}</h1>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Link from 'next/link';
+import Image from 'next/image';
 import { posts } from '../../lib/posts';
 
 export default function Blog() {
@@ -15,7 +16,7 @@ export default function Blog() {
             <article key={post.slug} className="p-6 rounded-2xl border border-[var(--card-border)] bg-white shadow-sm">
               {post.cover && (
                 <div className="mb-4 overflow-hidden rounded-xl">
-                  <img src={post.cover} alt={post.title} className="w-full h-48 object-cover" />
+                  <Image src={post.cover} alt={post.title} width={800} height={192} className="w-full h-48 object-cover" />
                 </div>
               )}
               <h2 className="text-2xl font-bold mb-2">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Link from 'next/link';
-import { Terminal, Cpu, Globe, Zap, BarChart3, Binary } from 'lucide-react';
+import { Cpu, Zap, Binary } from 'lucide-react';
 
 export default function Home() {
   return (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { Menu, X } from "lucide-react";
 
 export default function Header() {
@@ -11,7 +12,7 @@ export default function Header() {
     <header className="border-b border-orange-100 bg-white/90 backdrop-blur-xl shadow-sm">
       <div className="max-w-7xl mx-auto px-6 h-20 flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <img src="/logo.svg" alt="Tida Solutions" className="w-10 h-10 rounded-xl shadow-lg" />
+          <Image src="/logo.svg" alt="Tida Solutions" width={40} height={40} className="rounded-xl shadow-lg" />
           <span className="text-xl font-bold tracking-tight text-slate-800">Tida Solutions</span>
         </div>
 


### PR DESCRIPTION
Fixes #5

## 修正内容

- `page.tsx` の未使用インポート（Terminal, Globe, BarChart3）を削除
- `<img>` タグを next/image の `<Image>` に置き換え（no-img-element エラー解消）

Generated with [Claude Code](https://claude.ai/code)