### PR TITLE
feat: 採用ページにお問い合わせフォームを実装

### DIFF
--- a/src/app/api/recruit/contact/route.ts
+++ b/src/app/api/recruit/contact/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+function isValidEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+export async function POST(req: NextRequest) {
+  const body = await req.json().catch(() => null);
+
+  if (!body) {
+    return NextResponse.json({ error: 'リクエストが不正です。' }, { status: 400 });
+  }
+
+  const { name, email, job, message } = body as {
+    name?: string;
+    email?: string;
+    job?: string;
+    message?: string;
+  };
+
+  if (!name?.trim() || !email?.trim() || !job?.trim() || !message?.trim()) {
+    return NextResponse.json({ error: 'すべての項目を入力してください。' }, { status: 400 });
+  }
+
+  if (!isValidEmail(email)) {
+    return NextResponse.json({ error: 'メールアドレスの形式が正しくありません。' }, { status: 400 });
+  }
+
+  if (message.trim().length < 10) {
+    return NextResponse.json({ error: 'メッセージは10文字以上で入力してください。' }, { status: 400 });
+  }
+
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) {
+    console.error('RESEND_API_KEY is not set');
+    return NextResponse.json({ error: 'メール送信の設定が完了していません。' }, { status: 500 });
+  }
+
+  const adminEmail = 'taichi@tida-intern.com';
+  const fromAddress = 'Tida Solutions Careers <onboarding@resend.dev>';
+
+  // Send confirmation email to applicant
+  const confirmationRes = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from: fromAddress,
+      to: [email],
+      subject: '【Tida Solutions】採用お問い合わせを受け付けました',
+      html: `
+        <p>${name} 様</p>
+        <p>この度は Tida Solutions の採用にご興味をお持ちいただきありがとうございます。</p>
+        <p>以下の内容でお問い合わせを受け付けました。担当者より改めてご連絡いたします。</p>
+        <hr />
+        <p><strong>氏名：</strong>${name}</p>
+        <p><strong>メールアドレス：</strong>${email}</p>
+        <p><strong>希望職種：</strong>${job}</p>
+        <p><strong>メッセージ：</strong></p>
+        <p style="white-space:pre-wrap">${message}</p>
+        <hr />
+        <p>Tida Solutions Inc.<br />採用担当</p>
+      `,
+    }),
+  });
+
+  if (!confirmationRes.ok) {
+    const err = await confirmationRes.text();
+    console.error('Failed to send confirmation email:', err);
+    return NextResponse.json({ error: 'メール送信に失敗しました。しばらく経ってからお試しください。' }, { status: 500 });
+  }
+
+  // Send notification email to admin
+  await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from: fromAddress,
+      to: [adminEmail],
+      subject: `【採用問い合わせ】${name} 様より（${job}）`,
+      html: `
+        <p>採用ページからお問い合わせがありました。</p>
+        <hr />
+        <p><strong>氏名：</strong>${name}</p>
+        <p><strong>メールアドレス：</strong><a href="mailto:${email}">${email}</a></p>
+        <p><strong>希望職種：</strong>${job}</p>
+        <p><strong>メッセージ：</strong></p>
+        <p style="white-space:pre-wrap">${message}</p>
+      `,
+    }),
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/recruit/page.tsx
+++ b/src/app/recruit/page.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Link from 'next/link';
 import { Mail, Briefcase, Users } from 'lucide-react';
+import RecruitContactForm from '@/components/RecruitContactForm';
 
 export default function Recruit() {
   return (
@@ -40,14 +41,10 @@ export default function Recruit() {
         </section>
 
         <section className="mb-12">
-          <h2 className="text-2xl font-bold mb-4 flex items-center gap-2"><Mail size={18}/> 応募方法</h2>
-          <p className="text-slate-600 mb-4">以下のメールアドレスに、履歴書（PDF）と職務経歴書（任意）をお送りください。件名は「採用応募：職種名 - 氏名」としてください。</p>
+          <h2 className="text-2xl font-bold mb-4 flex items-center gap-2"><Mail size={18}/> 応募・お問い合わせ</h2>
+          <p className="text-slate-600 mb-4">下記フォームからお気軽にお問い合わせください。メールでのご連絡も歓迎しております。</p>
           <a href="mailto:taichi@tida-intern.com?subject=採用応募" className="inline-flex items-center gap-2 bg-(--accent) text-white px-4 py-3 rounded-md font-bold hover:opacity-90 transition">taichi@tida-intern.com</a>
-        </section>
-
-        <section>
-          <h3 className="text-lg font-semibold mb-2">その他</h3>
-          <p className="text-slate-600">ご質問や採用に関するご相談は上記メールアドレスまでお気軽にご連絡ください。</p>
+          <RecruitContactForm />
         </section>
       </main>
 

--- a/src/components/RecruitContactForm.tsx
+++ b/src/components/RecruitContactForm.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Send, CheckCircle, AlertCircle } from 'lucide-react';
+
+type Status = 'idle' | 'loading' | 'success' | 'error';
+
+const jobOptions = [
+  'AIエンジニア（受託開発・研究推進）',
+  'プロダクトマネージャー（AIプロダクト）',
+  'グロース・パートナー（海外技術連携）',
+  'その他',
+];
+
+export default function RecruitContactForm() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [job, setJob] = useState('');
+  const [message, setMessage] = useState('');
+  const [status, setStatus] = useState<Status>('idle');
+  const [errorMsg, setErrorMsg] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setStatus('loading');
+    setErrorMsg('');
+
+    try {
+      const res = await fetch('/api/recruit/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, email, job, message }),
+      });
+
+      if (res.ok) {
+        setStatus('success');
+        setName('');
+        setEmail('');
+        setJob('');
+        setMessage('');
+      } else {
+        const data = await res.json().catch(() => ({}));
+        setErrorMsg(data.error || 'エラーが発生しました。しばらく経ってからお試しください。');
+        setStatus('error');
+      }
+    } catch {
+      setErrorMsg('ネットワークエラーが発生しました。');
+      setStatus('error');
+    }
+  };
+
+  if (status === 'success') {
+    return (
+      <div className="mt-8 rounded-2xl border border-green-200 bg-green-50 p-8 text-center">
+        <CheckCircle size={40} className="mx-auto mb-4 text-green-500" />
+        <p className="text-lg font-bold text-green-700">送信が完了しました！</p>
+        <p className="mt-2 text-slate-600">
+          お問い合わせいただきありがとうございます。確認メールをお送りしましたので、ご確認ください。
+          担当者より折り返しご連絡いたします。
+        </p>
+        <button
+          onClick={() => setStatus('idle')}
+          className="mt-6 text-sm text-slate-500 underline hover:text-slate-700"
+        >
+          別のメッセージを送る
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-8 space-y-5">
+      <div>
+        <label htmlFor="recruit-name" className="block text-sm font-semibold text-slate-700 mb-1">
+          氏名 <span className="text-red-500">*</span>
+        </label>
+        <input
+          id="recruit-name"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+          placeholder="山田 太郎"
+          className="w-full rounded-lg border border-slate-200 bg-white px-4 py-3 text-slate-800 placeholder-slate-400 focus:border-[var(--accent)] focus:outline-none focus:ring-2 focus:ring-orange-100 transition"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="recruit-email" className="block text-sm font-semibold text-slate-700 mb-1">
+          メールアドレス <span className="text-red-500">*</span>
+        </label>
+        <input
+          id="recruit-email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          placeholder="taro@example.com"
+          className="w-full rounded-lg border border-slate-200 bg-white px-4 py-3 text-slate-800 placeholder-slate-400 focus:border-[var(--accent)] focus:outline-none focus:ring-2 focus:ring-orange-100 transition"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="recruit-job" className="block text-sm font-semibold text-slate-700 mb-1">
+          希望職種 <span className="text-red-500">*</span>
+        </label>
+        <select
+          id="recruit-job"
+          value={job}
+          onChange={(e) => setJob(e.target.value)}
+          required
+          className="w-full rounded-lg border border-slate-200 bg-white px-4 py-3 text-slate-800 focus:border-[var(--accent)] focus:outline-none focus:ring-2 focus:ring-orange-100 transition"
+        >
+          <option value="">選択してください</option>
+          {jobOptions.map((opt) => (
+            <option key={opt} value={opt}>
+              {opt}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="recruit-message" className="block text-sm font-semibold text-slate-700 mb-1">
+          メッセージ <span className="text-red-500">*</span>
+        </label>
+        <textarea
+          id="recruit-message"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          required
+          minLength={10}
+          rows={5}
+          placeholder="自己紹介や応募動機、ご質問などをご記入ください。"
+          className="w-full rounded-lg border border-slate-200 bg-white px-4 py-3 text-slate-800 placeholder-slate-400 focus:border-[var(--accent)] focus:outline-none focus:ring-2 focus:ring-orange-100 transition resize-none"
+        />
+      </div>
+
+      {status === 'error' && (
+        <div className="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-600 text-sm">
+          <AlertCircle size={16} />
+          {errorMsg}
+        </div>
+      )}
+
+      <button
+        type="submit"
+        disabled={status === 'loading'}
+        className="inline-flex items-center gap-2 rounded-full bg-[var(--accent)] px-8 py-3 font-bold text-white shadow-[0_4px_14px_rgba(249,115,22,0.3)] transition hover:opacity-90 hover:scale-[1.02] disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {status === 'loading' ? (
+          <>
+            <span className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+            送信中…
+          </>
+        ) : (
+          <>
+            <Send size={16} />
+            送信する
+          </>
+        )}
+      </button>
+    </form>
+  );
+}


### PR DESCRIPTION
Closes #13

採用ページにお問い合わせフォームを実装しました。Resend REST APIを使用して、応募者への確認メールと管理者への通知メールを送信します。

Generated with [Claude Code](https://claude.ai/code)